### PR TITLE
Disables the interactivePopGestureRecognizer to avoid conflicts

### DIFF
--- a/Sources/MediaEditor.swift
+++ b/Sources/MediaEditor.swift
@@ -124,6 +124,11 @@ open class MediaEditor: UINavigationController {
         super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
     }
 
+    open override func viewDidLoad() {
+        super.viewDidLoad()
+        interactivePopGestureRecognizer?.isEnabled = false
+    }
+
     public override func viewWillDisappear(_ animated: Bool) {
         super.viewWillAppear(animated)
         currentCapability = nil

--- a/Tests/MediaEditorTests.swift
+++ b/Tests/MediaEditorTests.swift
@@ -30,6 +30,14 @@ class MediaEditorTests: XCTestCase {
         expect(mediaEditor.modalPresentationStyle).to(equal(.fullScreen))
     }
 
+    func testDisableInteractivePopGestureRecognizer() {
+        let mediaEditor = MediaEditor(image)
+
+        mediaEditor.viewDidLoad()
+
+        expect(mediaEditor.interactivePopGestureRecognizer?.isEnabled).to(beFalse())
+    }
+
     func testHubDelegate() {
         let mediaEditor = MediaEditor(image)
 


### PR DESCRIPTION
Fixes #7 

### To test

Using an iOS 12 simulator and/or device:

1. Tap Crop
2. Grab the left handle in the crop screen
3. Check that it works properly

Also, try to swipe left-from-right. The view controller should not start to pop out.