### PR TITLE
Loads Photos from iCloud

### DIFF
--- a/Sources/Extensions/PHAsset+AsyncImage.swift
+++ b/Sources/Extensions/PHAsset+AsyncImage.swift
@@ -33,7 +33,8 @@ extension PHAsset: AsyncImage {
         options.deliveryMode = .opportunistic
         options.version = .current
         options.resizeMode = .fast
-        let requestID = PHImageManager.default().requestImage(for: self, targetSize: CGSize(width: pixelWidth, height: pixelHeight), contentMode: .default, options: options) { image, info in
+        options.isNetworkAccessAllowed = true
+        let requestID = PHImageManager.default().requestImage(for: self, targetSize: UIScreen.main.bounds.size, contentMode: .default, options: options) { image, info in
             guard let image = image else {
                 finishedRetrievingThumbnail(nil)
                 return

--- a/Sources/Extensions/PHAsset+AsyncImage.swift
+++ b/Sources/Extensions/PHAsset+AsyncImage.swift
@@ -51,6 +51,7 @@ extension PHAsset: AsyncImage {
         let options = PHImageRequestOptions()
         options.deliveryMode = .highQualityFormat
         options.version = .current
+        options.isNetworkAccessAllowed = true
         let requestID = PHImageManager.default().requestImage(for: self, targetSize: CGSize(width: pixelWidth, height: pixelHeight), contentMode: .default, options: options) { image, info in
             guard let image = image else {
                 finishedRetrievingFullImage(nil)


### PR DESCRIPTION
Fixes #10 

### To test

1. Load a photo that exists only in iCloud (and not on your device)
2. Tap Crop
3. Check that the photo loads correctly

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
