### PR TITLE
Replace TOCropViewController with CropViewController

### DIFF
--- a/MediaEditor.podspec
+++ b/MediaEditor.podspec
@@ -22,5 +22,5 @@ Pod::Spec.new do |s|
     'MediaEditor' => 'Sources/**/*.{xcassets}'
   }
 
-  s.dependency 'TOCropViewController', '~> 2.5.3'
+  s.dependency 'CropViewController', '~> 2.5.3'
 end

--- a/MediaEditor.xcodeproj/project.pbxproj
+++ b/MediaEditor.xcodeproj/project.pbxproj
@@ -125,7 +125,7 @@
 		8B5046AC23D7C9AD00068F66 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		8B5046AF23D7C9AD00068F66 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		8B5046B123D7C9AD00068F66 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		8B5046B723D7CCBD00068F66 /* TOCropViewController.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = TOCropViewController.framework; path = Carthage/Build/iOS/TOCropViewController.framework; sourceTree = "<group>"; };
+		8B5046B723D7CCBD00068F66 /* CropViewController.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CropViewController.framework; path = Carthage/Build/iOS/CropViewController.framework; sourceTree = "<group>"; };
 		8B5046C423D7CE1600068F66 /* UIImage+AsyncImage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIImage+AsyncImage.swift"; sourceTree = "<group>"; };
 		8B5046C523D7CE1600068F66 /* PHAsset+AsyncImage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "PHAsset+AsyncImage.swift"; sourceTree = "<group>"; };
 		8B5046C623D7CE1600068F66 /* MediaEditor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaEditor.swift; sourceTree = "<group>"; };
@@ -156,7 +156,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				8B5046BB23D7CCD000068F66 /* TOCropViewController.framework in Frameworks */,
+				8B5046BB23D7CCD000068F66 /* CropViewController.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -164,7 +164,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				8B5046B823D7CCBD00068F66 /* TOCropViewController.framework in Frameworks */,
+				8B5046B823D7CCBD00068F66 /* CropViewController.framework in Frameworks */,
 				8B5046B623D7C9E300068F66 /* MediaEditor.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -346,7 +346,7 @@
 			isa = PBXGroup;
 			children = (
 				8B5046FC23D7D16A00068F66 /* Nimble.framework */,
-				8B5046B723D7CCBD00068F66 /* TOCropViewController.framework */,
+				8B5046B723D7CCBD00068F66 /* CropViewController.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ github "wordpress-mobile/MediaEditor-iOS"
 
 2. Run `carthage update`
 
-3. From the `Carthage/Build` folder, import `MediaEditor.framework` and `TOCropViewController.framework` into your Xcode project.
+3. From the `Carthage/Build` folder, import `MediaEditor.framework` and `CropViewController.framework` into your Xcode project.
 
 4. Follow the remaining steps on [Getting Started with Carthage](https://github.com/Carthage/Carthage#getting-started) to finish integrating the framework.
 

--- a/Sources/Capabilities/Crop/MediaEditorCropZoomRotate.swift
+++ b/Sources/Capabilities/Crop/MediaEditorCropZoomRotate.swift
@@ -1,15 +1,15 @@
 import UIKit
-import TOCropViewController
+import CropViewController
 
-typealias MediaEditorCropZoomRotate = TOCropViewController
+typealias MediaEditorCropZoomRotate = CropViewController
 
-extension TOCropViewController: MediaEditorCapability {
+extension CropViewController: MediaEditorCapability {
     public static var name = "Crop, Zoom, Rotate"
 
     public static var icon = UIImage(named: "gridicons-crop", in: .mediaEditor, compatibleWith: nil)!
 
     public static func initialize(_ image: UIImage, onFinishEditing: @escaping (UIImage, [MediaEditorOperation]) -> (), onCancel: @escaping () -> ()) -> CapabilityViewController {
-        let cropViewController = TOCropViewController(image: image)
+        let cropViewController = CropViewController(image: image)
 
         weak var toCrop = cropViewController
 

--- a/Sources/Capabilities/Crop/TOCropViewController+Ext.swift
+++ b/Sources/Capabilities/Crop/TOCropViewController+Ext.swift
@@ -1,7 +1,7 @@
-import TOCropViewController
+import CropViewController
 
-extension TOCropViewController {
-    // TOCropViewController sometimes resize the image by 1, 2 or 3 points automatically.
+extension CropViewController {
+    // CropViewController sometimes resize the image by 1, 2 or 3 points automatically.
     // In those cases we're not considering that as a cropping action.
     var isCropped: Bool {
         return abs(imageSizeDiscardingRotation.width - image.size.width) > 4 ||

--- a/Tests/Capabilities/Crop/MediaEditorCropZoomRotateTests.swift
+++ b/Tests/Capabilities/Crop/MediaEditorCropZoomRotateTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-import TOCropViewController
+import CropViewController
 import Nimble
 
 @testable import MediaEditor
@@ -17,7 +17,7 @@ class MediaEditorCropZoomRotateTests: XCTestCase {
     func testDoNotHideNavigation() {
         let mediaEditorCrop = MediaEditorCropZoomRotate.initialize(image, onFinishEditing: { _, _ in }, onCancel: {})
 
-        let viewController = mediaEditorCrop as? TOCropViewController
+        let viewController = mediaEditorCrop as? CropViewController
 
         expect(viewController?.hidesNavigationBar).to(beFalse())
     }
@@ -30,7 +30,7 @@ class MediaEditorCropZoomRotateTests: XCTestCase {
                 onFinishEditingCalled = true
             },
             onCancel: {})
-        let viewController = mediaEditorCrop as? TOCropViewController
+        let viewController = mediaEditorCrop as? CropViewController
 
         viewController?.onDidCropToRect?(image, .zero, 0)
 
@@ -46,7 +46,7 @@ class MediaEditorCropZoomRotateTests: XCTestCase {
                 onCancelCalled = true
             }
         )
-        let viewController = mediaEditorCrop as? TOCropViewController
+        let viewController = mediaEditorCrop as? CropViewController
 
         viewController?.onDidFinishCancelled?(true)
 
@@ -58,7 +58,7 @@ class MediaEditorCropZoomRotateTests: XCTestCase {
 
         mediaEditorCrop.apply(styles: [.rotateCounterclockwiseButtonHidden: true])
 
-        let viewController = mediaEditorCrop as? TOCropViewController
+        let viewController = mediaEditorCrop as? CropViewController
         expect(viewController?.toolbar.rotateCounterclockwiseButtonHidden).to(beTrue())
     }
 

--- a/Tests/MediaEditorTests.swift
+++ b/Tests/MediaEditorTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-import TOCropViewController
+import CropViewController
 import Nimble
 
 @testable import MediaEditor


### PR DESCRIPTION
This PR replaced TOCropViewController with it's swift wrapper CropViewController, which enhances project structure for Swift projects already including CropViewController for other use-cases