### PR TITLE
Drawing: Limit scale of rendered annotationview image

### DIFF
--- a/MediaEditor.podspec
+++ b/MediaEditor.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'MediaEditor'
-  s.version          = '1.2.0'
+  s.version          = '1.2.1-beta.1'
   s.summary          = 'An extensible Media Editor for iOS.'
 
   s.description      = <<-DESC

--- a/MediaEditor.podspec
+++ b/MediaEditor.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'MediaEditor'
-  s.version          = '1.2.1-beta.1'
+  s.version          = '1.2.1'
   s.summary          = 'An extensible Media Editor for iOS.'
 
   s.description      = <<-DESC

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,7 @@
+1.2.1
+-----
+* Improve memory usage of AnnotationView when rendering drawings
+ 
 1.2.0
 -----
 * Replace TOCropViewController with CropViewController

--- a/Sources/Capabilities/Drawing/MediaEditorAnnotationView.swift
+++ b/Sources/Capabilities/Drawing/MediaEditorAnnotationView.swift
@@ -178,7 +178,10 @@ class MediaEditorAnnotationView: UIView {
 
         let canvasViewImage = canvasView.drawing.image(from: canvasView.bounds, scale: UIScreen.main.scale)
 
-        let renderer = UIGraphicsImageRenderer(size: targetSize, format: .default())
+        let format = UIGraphicsImageRendererFormat()
+        format.scale = 1
+
+        let renderer = UIGraphicsImageRenderer(size: targetSize, format: format)
         let renderedImage = renderer.image { context in
             imageViewImage.draw(at: .zero)
             canvasViewImage.draw(in: CGRect(origin: .zero, size: targetSize))


### PR DESCRIPTION
Improves https://github.com/wordpress-mobile/WordPress-iOS/issues/14575, and fixes crashes that I was seeing.

`UIGraphicsImageRendererFormat` defaults to using the scale of the current screen, which was resulting in images 2 or 3x larger than their originals. This PR updates the renderer format to use a scale of 1.

**To test**

- Build and run
- Choose a device photo (I used the pink flowers) and draw something on top of it
- Ensure you have the Debug Navigator open in Xcode (showing CPU, memory, etc)
- When you tap Done, you should just see a small momentary increase in memory:

<img width="255" alt="Screenshot 2020-09-03 at 19 44 11" src="https://user-images.githubusercontent.com/4780/92155435-4ce9a980-ee1f-11ea-98a8-f668b45507ff.png">

- Prior to this PR (you can test develop) you should see a more prolonged and much larger increase in memory. My simulator freezes up for a long time when this happens:

<img width="252" alt="Screenshot 2020-09-03 at 19 45 05" src="https://user-images.githubusercontent.com/4780/92155483-625ed380-ee1f-11ea-836f-ff8d251aed2d.png">

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
