### PR TITLE
[Tooling] Standardize podspec format

### DIFF
--- a/MediaEditor.podspec
+++ b/MediaEditor.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
 
   s.homepage      = 'https://github.com/wordpress-mobile/MediaEditor-iOS'
   s.license       = { :type => 'GPLv2', :file => 'LICENSE' }
-  s.author        = { 'The WordPress Mobile Team' => 'mobile@automattic.com' }
+  s.author        = { 'The WordPress Mobile Team' => 'mobile@wordpress.org' }
   
   s.ios.deployment_target = '11.0'
   s.swift_version = '5.0'

--- a/MediaEditor.podspec
+++ b/MediaEditor.podspec
@@ -1,20 +1,20 @@
 Pod::Spec.new do |s|
-  s.name             = 'MediaEditor'
-  s.version          = '1.2.1'
-  s.summary          = 'An extensible Media Editor for iOS.'
+  s.name          = 'MediaEditor'
+  s.version       = '1.2.1'
 
-  s.description      = <<-DESC
-                       An extensible Media Editor for iOS that allows editing single or multiple images.
-                       DESC
+  s.summary       = 'An extensible Media Editor for iOS.'
+  s.description   = <<-DESC
+                    An extensible Media Editor for iOS that allows editing single or multiple images.
+                  DESC
 
-  s.homepage         = 'https://github.com/wordpress-mobile/MediaEditor-iOS.git'
-  s.license          = { :type => 'GPLv2', :file => 'LICENSE' }
-  s.author           = { 'Automattic' => 'mobile@automattic.com' }
-  s.social_media_url = "http://twitter.com/WordPressiOS"
-  s.source           = { :git => 'https://github.com/wordpress-mobile/MediaEditor-iOS.git', :tag => s.version.to_s }
+  s.homepage      = 'https://github.com/wordpress-mobile/MediaEditor-iOS'
+  s.license       = { :type => 'GPLv2', :file => 'LICENSE' }
+  s.author        = { 'The WordPress Mobile Team' => 'mobile@automattic.com' }
+  
   s.ios.deployment_target = '11.0'
   s.swift_version = '5.0'
 
+  s.source        = { :git => 'https://github.com/wordpress-mobile/MediaEditor-iOS.git', :tag => s.version.to_s }
   s.module_name = "MediaEditor"
   s.source_files = 'Sources/**/*.{h,m,swift}'
   s.resources = 'Sources/**/*.{storyboard}'


### PR DESCRIPTION
As part of paaHJt-Vl-p2, this simply standardize the podspec file so that all our pods use a similar format and structure, with similar keys and common values.

See wordpress-mobile/WordPressAuthenticator-iOS#582 for the rules I decided to follow on the format and content standardization.