### PR TITLE
Use `XCTExpectFailure` instead of skipping tests in scheme

### DIFF
--- a/MediaEditor.xcodeproj/xcshareddata/xcschemes/MediaEditor.xcscheme
+++ b/MediaEditor.xcodeproj/xcshareddata/xcschemes/MediaEditor.xcscheme
@@ -37,14 +37,6 @@
                BlueprintName = "Tests"
                ReferencedContainer = "container:MediaEditor.xcodeproj">
             </BuildableReference>
-            <SkippedTests>
-               <Test
-                  Identifier = "MediaEditorHubTests/testDoNotShowActivityIndicatorIfImageIsNotBeingLoaded()">
-               </Test>
-               <Test
-                  Identifier = "MediaEditorHubTests/testShowActivityIndicatorWhenSwipingToAnImageBeingLoaded()">
-               </Test>
-            </SkippedTests>
          </TestableReference>
       </Testables>
    </TestAction>

--- a/Tests/MediaEditorHubTests.swift
+++ b/Tests/MediaEditorHubTests.swift
@@ -105,6 +105,7 @@ class MediaEditorHubTests: XCTestCase {
         hub.imagesCollectionView.reloadData()
         hub.loadingImage(at: 0)
 
+        XCTExpectFailure("We noticed this test failing in https://github.com/wordpress-mobile/MediaEditor-iOS/pull/28 but did not have the bandwidth to fix it")
         hub.collectionView(hub.thumbsCollectionView, didSelectItemAt: IndexPath(row: 1, section: 0))
 
         expect(hub.activityIndicatorView.isHidden).to(beTrue())
@@ -118,6 +119,7 @@ class MediaEditorHubTests: XCTestCase {
         hub.loadingImage(at: 1)
         hub.loadingImage(at: 0)
 
+        XCTExpectFailure("We noticed this test failing in https://github.com/wordpress-mobile/MediaEditor-iOS/pull/28 but did not have the bandwidth to fix it")
         hub.collectionView(hub.thumbsCollectionView, didSelectItemAt: IndexPath(row: 1, section: 0))
 
         expect(hub.activityIndicatorView.isHidden).to(beFalse())


### PR DESCRIPTION
My concern with using the scheme (or a Test Plan) to skip tests is that the setting is tucked away behind multiple UI layers and mouse clicks. I worry that we'll forget about it.

By still running these two tests and marking their failures as expected, we make the issue more visible.

---

PR submission checklist:

- [x] I have considered adding unit tests where possible. – N.A.
- [x] I have considered adding accessibility improvements for my changes. – N.A.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. – N.A.