### PR TITLE
Fix some view lifecycle inconsistencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ _None._
 
 ### Bug Fixes
 
-_None._
+- Fix a `viewWillDisappear` method calling `super.viewWillAppear` [#40]
 
 ### Internal Changes
 

--- a/Sources/Capabilities/Filters/MediaEditorFilters.swift
+++ b/Sources/Capabilities/Filters/MediaEditorFilters.swift
@@ -72,6 +72,7 @@ class MediaEditorFilters: UIViewController {
     private var selectedFilterIndex = IndexPath(row: 0, section: 0)
 
     override func viewDidLoad() {
+        super.viewDidLoad()
         imageView.image = image
         filtersCollectionView.dataSource = self
         filtersCollectionView.delegate = self

--- a/Sources/MediaEditor.swift
+++ b/Sources/MediaEditor.swift
@@ -141,7 +141,7 @@ open class MediaEditor: UINavigationController {
     }
 
     public override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillAppear(animated)
+        super.viewWillDisappear(animated)
         currentCapability = nil
     }
 


### PR DESCRIPTION
I run into this while looking into https://github.com/wordpress-mobile/WordPress-iOS/issues/20849

---

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
