### PR TITLE
Merge 1.2.2 stable release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ _None._
 
 ### Bug Fixes
 
-- Fix a `viewWillDisappear` method calling `super.viewWillAppear` [#40]
+_None._
 
 ### Internal Changes
 
@@ -43,6 +43,16 @@ _None._
 ### Bug Fixes
 
 _None._
+
+### Internal Changes
+
+_None._
+
+## 1.2.2
+
+### Bug Fixes
+
+- Fix a `viewWillDisappear` method calling `super.viewWillAppear` [#40]
 
 ### Internal Changes
 

--- a/MediaEditor.podspec
+++ b/MediaEditor.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'MediaEditor'
-  s.version       = '1.2.1'
+  s.version       = '1.2.2'
 
   s.summary       = 'An extensible Media Editor for iOS.'
   s.description   = <<~DESC


### PR DESCRIPTION


This version bump PR is part of the code freeze workflow for WordPress iOS 22.6 and is here only to leave a breadcrumb in the release process. Once CI is green, I will push the tag for this version and, once that is successfully deployed, admin-merge this.