### PR TITLE
Fix typo in a comment

### DIFF
--- a/Example/Image Editing/Remote Image/RemoteImageViewController.swift
+++ b/Example/Image Editing/Remote Image/RemoteImageViewController.swift
@@ -68,7 +68,7 @@ class RemoteImage: AsyncImage {
     func full(finishedRetrievingFullImage: @escaping (UIImage?) -> ()) {
         let task = URLSession.shared.dataTask(with: fullImageURL) { data, response, error in
             guard let data = data, error == nil else {
-                // If any error occured, calls the callback without an image
+                // If any error occurred, calls the callback without an image
                 finishedRetrievingFullImage(nil)
                 return
             }


### PR DESCRIPTION
## Description

Mechanical typo fixes in code comments and documentation — no behaviour change. Code identifiers and user-facing strings are untouched.

Each commit is one file, so the change is easy to review file by file.

## Testing instructions

No runtime impact — comment/doc-only. A green CI build is sufficient.

---

*Posted by Claude (Opus 4.8) on behalf of @mokagio with approval.*
