### PR TITLE
ci: AINFRA-3001: Use CI toolkit 6.3.0 for better artifact caching

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -10,7 +10,7 @@ env:
 # Nodes with values to reuse in the pipeline.
 common_params:
   plugins: &common_plugins
-    - automattic/a8c-ci-toolkit#5.3.1
+    - automattic/a8c-ci-toolkit#6.3.0
 
 # This is the default pipeline – it will build and test the library
 steps:


### PR DESCRIPTION
The majors crossed (4.0.0, 5.0.0, 6.0.0) carry three breaking changes between them: pr_changed_files switching to exit codes, and two Windows-only script removals. MediaEditor-iOS calls install_gems, so we're good.

As of ~~6.1.0~~ 6.1.1, CI toolkit uses the Synology NAS on-premises on the macOS queue, falling back to S3 only when that's not available, resulting in lower S3 hits.

The version stays inline in `.buildkite/pipeline.yml` because this repo has no `.buildkite/shared-pipeline-vars`.